### PR TITLE
memory optimization

### DIFF
--- a/shapes/Mesh.js
+++ b/shapes/Mesh.js
@@ -13,9 +13,7 @@ export default class Mesh {
 
 Mesh.prototype.clone = function () {
   let mesh = new Mesh(this.textureImg);
-  mesh.meshTriangles = this.meshTriangles.map((triangle) => {
-    return triangle.clone();
-  });
+  mesh.meshTriangles = this.meshTriangles;
   return mesh;
 };
 

--- a/shapes/TestShapes/MeshCuboid.js
+++ b/shapes/TestShapes/MeshCuboid.js
@@ -158,9 +158,7 @@ export default class MeshCuboid {
 
 MeshCuboid.prototype.clone = function () {
   let newMesh = new MeshCuboid(this.w, this.l, this.h);
-  newMesh.meshTriangles = this.meshTriangles.map((triangle) => {
-    return triangle.clone();
-  });
+  newMesh.meshTriangles = this.meshTriangles;
 
   newMesh.textureImg = this.textureImg;
   return newMesh;


### PR DESCRIPTION
make the meshTriangles be ref of the array of the og meshTriangles so it wont use copies of it, taking up RAM space. i dont see any diff in the task manager tho but its better than not doing it